### PR TITLE
Fix: Clicking on homepage from a Google search result

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,7 +28,7 @@ if (pathname === "/search") {
 
 // --- Homepage logic (/ or /?zx=...) ---
 if (
-  pathname === "/" &&
+  (pathname === "/" || pathname === "/webhp") &&
   (!searchParams.has("q") || searchParams.has("zx"))
 ) {
   const hideHomepageStuff = () => {
@@ -45,15 +45,7 @@ if (
       el.style.cursor = 'default';          // remove pointer cursor
 
       // remove hover background
-      el.addEventListener('mouseenter', () => {
-        el.style.background = 'transparent';
-      });
-      el.addEventListener('mouseover', () => {
-        el.style.background = 'transparent';
-      });
-      el.addEventListener('mousemove', () => {
-        el.style.background = 'transparent';
-      });
+      ['mouseenter', 'mouseover', 'mousemove'].forEach(evt => el.addEventListener(evt, () => el.style.background = 'transparent'));
     });
 
     // change "+" icon to search icon

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Google AI Overviews and Mode",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Remove AI Overviews and Mode from search results for a cleaner, traditional search page.",
   "homepage_url": "https://github.com/asahisuenaga/hide-google-ai",
   "icons": {


### PR DESCRIPTION
Issue: Visiting the homepage from a search result did not run homepage logic.
Fix: Add /webhp